### PR TITLE
Change token lifetime to token expiration date

### DIFF
--- a/protocols/BE01.md
+++ b/protocols/BE01.md
@@ -444,7 +444,7 @@ exact({
     "token_type": "bearer",
     "access_token": string,
     "refresh_token": string,
-    "expires_in": integer
+    "expires_at": date
 })
 ```
 The response gives the new token. This response is subject to the same conditions as the response to a password grant. The server **MAY** reuse the `access_token` or `refresh_token` but if it does so it **MUST** ensure that the validity of the new tokens extend to match the new expiry time.


### PR DESCRIPTION
Differences between the time of registering a token and time of a user receiving a token will differ, leading to the possibility of the user using a token that they think it's valid when that is not the case.