### PR TITLE
Children field in meta view has unnecessary information

### DIFF
--- a/protocols/BE01.md
+++ b/protocols/BE01.md
@@ -5,7 +5,7 @@
 
 | name                       | BE01               |
 |----------------------------|--------------------|
-| version                    | 0.1.5(pre-release) |
+| version                    | 0.1.6(pre-release) |
 | status                     | proposal           |
 | author                     | Ryan Wilson (rw86) |
 | serving component(s)       | backend            |
@@ -1061,9 +1061,7 @@ If the file is a directory and the query parameter "include\_children" is includ
         "file_path": string,
         "file_name": string,
         "id": string,
-        "supported_views": {},
         "type": string,
-        "metadata": metadata,
         "status": alternative([
             "uploading",
             "preprocessing",

--- a/protocols/BE01.md
+++ b/protocols/BE01.md
@@ -267,7 +267,7 @@ exact({
 ```
 (this will be referred to as `metadata` within patterns)
 
-The pattern `inital_metadata` is defined to be 
+The pattern `inital_metadata` is defined to be
 ```javascript
 {
     "version": 1,
@@ -333,7 +333,7 @@ Unless otherwise noted the form of the JSON response **MUST** match either:
     "error_data": optional(anything)
 }
 ```
-in the case of an error. `"error"` gives a standard error name found from a specification and `"error_description"` some human readable error message. `"user_message"` gives some error message suitable for displaying to the end-user. 
+in the case of an error. `"error"` gives a standard error name found from a specification and `"error_description"` some human readable error message. `"user_message"` gives some error message suitable for displaying to the end-user.
 
 
 Or
@@ -701,7 +701,7 @@ and the server **MUST** respond with details of the particular user if they exis
 ```
 
 ## Creating
-A client with the `admin` privilege may create a user by issuing a `POST` request to 
+A client with the `admin` privilege may create a user by issuing a `POST` request to
 ```
 http://backend.endpoint/users/<username>?action=create
 ```
@@ -728,7 +728,7 @@ The server **MUST** respond with one of:
 - a metadata error.
 
 ## Updating
-A client with the `admin` privilege may update a user by issuing a POST request to 
+A client with the `admin` privilege may update a user by issuing a POST request to
 ```
 http://backend.endpoint/users/<username>?action=update
 ```
@@ -785,7 +785,7 @@ or return a metadata error.
 If the change was successful the server **MUST** respond with a sucessful empty response.
 
 ## Deleting
-A client with the `admin` privilege may delete a user (who is not themself) by issuing a POST request to 
+A client with the `admin` privilege may delete a user (who is not themself) by issuing a POST request to
 ```
 http://backend.endpoint/users/<username>?action=delete
 ```
@@ -884,7 +884,7 @@ The server **MUST** respond with details of the particular project if it exists 
 Or, if the project does not exist, it **MUST** return http response code 404 and a "project\_not\_found" error.
 
 ## Creating
-A client with the `admin` privilege may create a project by issuing a POST request to 
+A client with the `admin` privilege may create a project by issuing a POST request to
 ```
 http://backend.endpoint/projects/<project_name>?action=create
 ```
@@ -910,7 +910,7 @@ The server **MUST** respond with one of:
 - a metadata error.
 
 ## Updating
-A client with the `project_admin` access right may update a project by issuing a POST request to 
+A client with the `project_admin` access right may update a project by issuing a POST request to
 ```
 http://backend.endpoint/projects/<project_name>?action=update
 ```
@@ -935,7 +935,7 @@ The server **MUST** respond with one of:
 - a metadata error.
 
 ## Deleting
-A client with the `admin` privilege (**NOTE** different to `project_admin` access rights) may delete a project by issuing a POST request to 
+A client with the `admin` privilege (**NOTE** different to `project_admin` access rights) may delete a project by issuing a POST request to
 ```
 http://backend.endpoint/projects/<project_name>?action=delete
 ```
@@ -945,7 +945,7 @@ The server **MUST** respond with one of:
 - http code 400 with error "project\_not\_found".
 
 ## Project grants
-A client with the `project_admin` access right or with the `admin` privilege may change a users access rights to a project by issuing a POST request to 
+A client with the `project_admin` access right or with the `admin` privilege may change a users access rights to a project by issuing a POST request to
 ```
 http://backend.endpoint/projects/<project_name>?action=update_grant
 ```
@@ -1054,14 +1054,16 @@ This metadata could be used, for example, to attach annotations to images.
 Clients providing an end-user interface to the files **SHOULD** indicate if a file is not in the "ready" state, for example by placing an icon or badge next to the file.
 
 ## Meta view - directories
-If the file is a directory and the query parameter "include\_children" is included in the request then the meta view will additionally match:
+If the file is a directory and the query parameter `"include_children"` is included in the request then the meta view will additionally match:
 ```javascript
 {
     "children": array({
         "file_path": string,
         "file_name": string,
         "id": string,
+        "supported_views": optional({}),
         "type": string,
+        "metadata": optional(metadata),
         "status": alternative([
             "uploading",
             "preprocessing",
@@ -1070,7 +1072,7 @@ If the file is a directory and the query parameter "include\_children" is includ
     })
 }
 ```
-where the "children" array contains the meta view for all the children of the directory. *NOTE:* the "include\_children" option is not recursive, child directories will not list their children.
+where the `"children"` array contains the meta view for all the children of the directory. The `"supported_views"` and `"metadata"` fields are optional, but the recommended behaviour is to omit them. *NOTE:* the `"include_children"` option is not recursive, child directories will not list their children.
 
 ## Meta view - raw files
 If files support the raw view then the meta view should match
@@ -1250,7 +1252,7 @@ Additionally it should support the tabular view:
 ```javascript
 {
     "supported_views": {
-        "tabular": { 
+        "tabular": {
             "columns": array(string),
             "rows": integer
         }
@@ -1286,7 +1288,7 @@ Additionally it should support the following view:
 ```javascript
 {
     "supported_views": {
-        "scalable_image": { 
+        "scalable_image": {
             "width": integer,
             "height": integer,
             "channels": array({
@@ -1320,7 +1322,7 @@ This view supports the following parameters
 | y\_offset     | y offset, in unscaled pixels, of the region requested from the top left corner                                               | assume = 0                                      |
 | width        | width, in unscaled pixels, of the region requested                                                                           | set so that x\_offset + width = image\_width      |
 | height       | height, in unscaled pixels, of the region requested                                                                          | set so that y\_offset + height = image\_height    |
-    
+
 
 The mimetype of a successful response **MUST** be "image/png".
 

--- a/protocols/BE02.md
+++ b/protocols/BE02.md
@@ -1,0 +1,1334 @@
+# BE01: Backend basic specification
+**THIS IS A DRAFT SPECIFICATION AND IS NOT FINAL**
+
+**THIS IS AN INTERMEDIATE RELEASE AND SHOULD NOT BE IMPLEMENTED**
+
+| name                       | BE01               |
+|----------------------------|--------------------|
+| version                    | 0.1.6(pre-release) |
+| status                     | proposal           |
+| author                     | Ryan Wilson (rw86) |
+| minor changes              | Ryosuke Minami     |
+| serving component(s)       | backend            |
+| consuming component(s)     | all                |
+| basic spec                 | yes                |
+| can be required by servers | yes                |
+| can be required by clients | yes                |
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+## License
+The content of this file is free to edit and distribute,
+under the following conditions:
+1. Names listed under the _author_ field in this file **MUST NOT** be removed
+(but **MAY** be added to).
+2. If any part of the content of this file is functionally altered, the
+resulting file **MUST** be renamed.
+3. This license must be distributed as part of the new file.
+
+## Changelog
+### Version 0.1
+View this version [here](https://rw86.host.cs.st-andrews.ac.uk/jh/backend_spec-v0.1.md.html)
+
+- First draft
+
+### Version 0.1.1
+View this version [here](https://rw86.host.cs.st-andrews.ac.uk/jh/backend_spec-v0.1.1.md.html)
+
+- Added an API to list available privileges.
+
+### Version 0.1.2
+View this version [here](https://rw86.host.cs.st-andrews.ac.uk/jh/backend_spec-v0.1.2.md.html)
+
+- Added an API to list available project roles.
+- Clarified permissions required to edit project grants.
+- Changed endpoint for listing user privileges
+
+### Version 0.1.3
+View this version [here](https://rw86.host.cs.st-andrews.ac.uk/jh/backend_spec-v0.1.3.md.html)
+
+- Removed the redundant "invalid\_metadata" error.
+- Moved some sections.
+- Fixed int type in properties.
+- Relaxed some **MUST** constraints to **SHOULD**
+- Creator of a project automatically gets `project_admin` access.
+- Made pattern for self-update stricter (made requests specifying unwritable metadata invalid).
+- Changed error for when "admin\_metadata" is specified in an update project request when the user is not a project admin (is now consistent with behaviour for users).
+- Filenames must be at least a single character.
+- Added an explicit error for grant requests with an invalid access level.
+- Added an explicit error for updating user privileges with a privilege.
+- There must not be an access level "none".
+- Allow backend to impose path length limits.
+- Added an error when attempting to write to a directory.
+- Directories are always in the "ready" state.
+- Clarified behaviour for object names with special characters
+- Newly created files now return their id as part of the response to the creation request.
+- Files now always have metadata, removed the delete metadata request.
+- Clarified that datetimes are in UTC for logging
+- Log messages can now be any JSON object
+- Added optional "real\_width" and "real\_height" attributes to zoomable images
+- File uploads by id must specify overwrite
+- Moving and copying files
+
+### Version 0.1.4
+View this version [here](https://rw86.host.cs.st-andrews.ac.uk/jh/BE01-v0.1.4.md.html)
+
+- Specified error when trying to move a directory inside itself
+- Added number matcher
+
+### Version 0.1.5
+- Added "user\_message" to error responses.
+- Made "error\_description" optional in error responses.
+- Spellchecking and consistency checks.
+- Added license.
+
+### Version 0.1.6
+- Meta view for tabular files now specifies whether each column is numerical or categorical.
+- Removed unnecessary fields from "children" of the directory meta view.
+
+# Foreword: URL
+
+Within this document the URL `http://backend.endpoint/` will be used to indicate the base URL of the backend server's API endpoint.
+
+# Foreword: matching notation
+
+At several points in this document a specification of a JSON value must be given. These specifications are to be interpreted as follows:
+
+## Literals
+The template `integer` matches any integer value.
+
+The template `number` matches any number value.
+
+The template `string` matches any string value.
+
+The template `boolean` matches any boolean value.
+
+The template `anything` matches any value.
+
+The template `not_present` requires that the property is not present in the containing object.
+## Raw object
+objects match if the value contains corresponding values for each given key. The value may have additional, not specified, keys.
+```javascript
+{
+    "required": integer
+}
+```
+matches
+```javascript
+{
+    "required": 1,
+    "other": 2
+}
+```
+but not
+```javascript
+{
+    "other": 2
+}
+```
+## Exact matching
+if an object is enclosed in `exact(...)` then it may not have additional keys, in particular
+```javascript
+exact({
+    "required": integer
+})
+```
+does not match
+```javascript
+{
+    "required": 1,
+    "other": 2
+}
+```
+## Raw array
+The array must match exactly including number of elements and the order of those elements.
+```javascript
+[1, 2, 3]
+```
+does not match
+```javascript
+[1, 2, 3, 4]
+```
+or
+```javascript
+[3, 2, 1]
+```
+
+## Optional values
+Templates of the form ` optional(x)` match either values that are not present or values that match `x`
+```javascript
+{
+    "required": integer,
+    "other": optional(2)
+}
+```
+matches
+```javascript
+{
+    "required": 1
+}
+```
+and
+```javascript
+{
+    "required": 1,
+    "other": 2
+}
+```
+but not
+```javascript
+{
+    "required": 1,
+    "other": 3
+}
+```
+## Variable length arrays
+templates of the form ` array(x)` matches an array whose elements all match `x`
+```javascript
+array({"a": 1})
+```
+matches
+```javascript
+[
+    {"a": 1},
+    {"a": 1, "b": 2},
+    {"a": 1, "c": 4}
+]
+```
+but not
+```javascript
+[
+    {"a": 1},
+    {"a": 1, "b": 2},
+    {"c": 4}
+]
+```
+## Alternatives
+templates of the form ` alternative([x, y, ..., z])` matches values who are matched by any of `x`, `y` ... `z`
+```javascript
+{
+    "url": alternative([
+        string,
+        {
+            "host": string,
+            "path": string
+        }
+    ])
+}
+```
+matches both
+```javascript
+{
+    "url": "http://example.com/path"
+}
+```
+
+and
+```javascript
+{
+    "url": {
+        "host": "http://example.com",
+        "path": "/path"
+    }
+}
+```
+## Not present
+```javascript
+{
+    "a": not_present
+}
+```
+
+is matched by
+```javascript
+{
+    "b": "thing"
+}
+```
+but not
+```javascript
+{
+    "a": "thing"
+}
+```
+
+# General notes
+## Names
+Names that identify objects (users, projects, files) should be non-empty and should be valid Unicode strings that do not contain the "/" character (except for paths, but not path components) or control characters from ISO 6429 C0 and C1. In the case that the client sends an invalid name as part of a URL the server behaviour is undefined (due to limitations of servers/frameworks in reliably handling such strings).
+
+The client **MUST** percent encode non URL-safe characters in a name when sending as part of a URL.
+
+## Atomicity of updates
+When an update is issued that causes an error (e.g. due to invalid data) the server **MUST NOT** have partially applied attributes in the update. In other words, updates are atomic.
+
+## Metadata
+Several objects have associated metadata objects for clients to use. This metadata **MUST** match
+
+```javascript
+exact({
+    "version": integer,
+    "namespaces": {}
+})
+```
+(this will be referred to as `metadata` within patterns)
+
+The pattern `inital_metadata` is defined to be
+```javascript
+{
+    "version": 1,
+    "namespaces": {}
+}
+```
+
+`"version"` is a monotonically increasing counter that increments by one on each metadata update. Clients should choose an appropriate namespace to store their data in: all namespaces not prefixed by an underscore are reserved. Groups are given exclusive access to the namespace given by their group name (upper-case without a dash e.g. "ML1").
+
+Example metadata might be
+```javascript
+{
+    "version": 12,
+    "namespaces": {
+        "ML1": {
+            "model_store_dir": "_reserved/ML1/models"
+        },
+        "HCI3": {
+            "display_name": "Microscopy analysis",
+            "creation_date": "...",
+            "created_by": "..."
+        }
+    }
+}
+```
+
+When setting metadata the backend must ensure that it matches the `metadata` template (this is ensured as part of validating the request, the invalid request error is used for values that don't match the request template, see the notes on "Basic Response") and that the version counter be exactly one greater than the one in the *current* version of the metadata (this allows race-free read-modify-write). If there is not any metadata currently stored then the version field must be 1.
+
+If the version number is not correct the server **SHOULD** respond with 400, "invalid\_metadata\_version". In this case the client should retry (starting again from read).
+
+# Indicating protocol support
+
+Upon request to the URL
+```
+http://backend.endpoint/_supported_protocols_
+```
+The server's unwrapped response **MUST** match:
+```javascript
+exactly({
+    "supported": array(string),
+    "required": array(string)
+})
+```
+
+`"supported"` **SHOULD** be an array of specification names (for example "BE01" for this specification) for specifications on which the client may rely on the server conforming to. **NOTE** that the *client* is not required to conform to the listed specification.
+
+`"required"` **MUST** be an array of specification names (for example "BE01" for this specification) on which the client may rely on the server conforming. The server **will assume** that the client conforms to these specifications also.
+
+A specification **MUST** only be listed in at most one of these arrays. Specifications **SHOULD** only be listed in `"required"` if the specification indicates at the top "can be required by servers". Clients may refuse to operate with servers who do not support or require some set of specifications however they **SHOULD** only do this when the specification indicates "can be required by clients".
+
+Note that names are always two upper-case characters followed by two digits.
+
+# Basic response
+Unless otherwise noted requests and responses are made in JSON, and the servers `Content-Type` header **SHOULD** indicate a mimetype of `application/json`. Requests and responses **SHOULD** be encoded in `UTF-8`.
+
+Unless otherwise noted the form of the JSON response **MUST** match either:
+```javascript
+{
+    "status": "error",
+    "error": string,
+    "error_description": optional(string),
+    "user_message": optional(string),
+    "error_data": optional(anything)
+}
+```
+in the case of an error. `"error"` gives a standard error name found from a specification and `"error_description"` some human readable error message. `"user_message"` gives some error message suitable for displaying to the end-user.
+
+
+Or
+```javascript
+{
+    "status": "success",
+    "data": anything
+}
+```
+In the case of success. The specification may use the phrase "unwrapped response" or "unwrapped content" to refer to the contents of the `"data"` attribute (the response is required or assumed to be successful).
+
+
+When the specification mentions the server "returning error `x`" the response should match
+```javascript
+{
+    "status": "error",
+    "error": x,
+    "error_description": string
+}
+```
+
+A successful response without any data should match
+```javascript
+{
+    "status": "success",
+    "data": {}
+}
+```
+
+If a client request does not match a pattern that the specification requires it matches the server **SHOULD** respond with error code 400 and error "invalid\_request". For example,
+```javascript
+{
+    "status": "error",
+    "error": "invalid_request",
+    "error_description": "The client made an invalid request."
+}
+```
+## Internal errors
+At any time the server **MAY** respond to a request with response code 500 and return error "internal\_server\_error".
+
+# OAuth
+**Note that responses here do not exactly follow the JSON response format**
+The URL
+```
+http://backend.endpoint/oauth/token
+```
+**MUST** be compliant with the following, reduced, specification of a token-granting endpoint from OAuth2.
+
+## Password grant
+Clients **MUST** send all parameters URL-encoded in the body of a `POST` request to the endpoint. Requests **MUST** be of the form
+```
+grant_type=password
+username=<username>
+password=<user_password>
+```
+
+The server then tries to authenticate the user and, if successful, **SHOULD** respond with
+
+```javascript
+exact({
+    "token_type": "bearer",
+    "access_token": string,
+    "refresh_token": string,
+    "expires_in": integer
+})
+```
+the `expires_in` field gives the validity period of the tokens, it applies to both the `access_token` and the `refresh_token`, it is specified in seconds and **SHOULD** be at least 6 hours.
+
+
+If the credentials were not valid the server **MUST** respond with http code 400 and response body
+```javascript
+exact({
+    "error": "invalid_grant",
+    "error_description": string
+})
+```
+
+If the client made a malformed request, e.g. missing parameters, then the server **MUST** respond with http code 400 and body
+```javascript
+exact({
+    "error": "invalid_request",
+    "error_description": string
+})
+```
+
+If the client indicates a `grant_type` option that the server does not support (not one of `"refresh_token"` or `"password"`) then the server **MUST** respond with http code 400 and body
+```javascript
+exact({
+    "error": "unsupported_grant_type",
+    "error_description": string
+})
+```
+
+## Refresh grant
+Long running clients (e.g. machine learning servers performing jobs that may take a long time to complete) may wish to get an access token with a longer validity time than the one they currently have to avoid having to cancel an operation or prompting the user for credentials. To meet this need backend servers **MUST** also support refresh token grants.
+
+When making a refresh token grant clients **MUST** send all parameters URL-encoded in the body of a `POST` request to the endpoint. Requests **MUST** be of the form
+```
+grant_type=refresh_token
+refresh_token=<refresh_token>
+```
+where `refresh_token` is a token that previously appeared in a server response and is still under its validity period.
+
+
+The server **MUST** check that the token is still inside its validity period and if it is **SHOULD** respond with a value matching
+```javascript
+exact({
+    "token_type": "bearer",
+    "access_token": string,
+    "refresh_token": string,
+    "expires_in": integer
+})
+```
+The response gives the new token. This response is subject to the same conditions as the response to a password grant. The server **MAY** reuse the `access_token` or `refresh_token` but if it does so it **MUST** ensure that the validity of the new tokens extend to match the new expiry time.
+
+## Using tokens
+After receiving a valid access token the client uses it to authenticate by setting its `Authorisation` http header to exactly
+```javascript
+"Bearer " + access_token
+```
+in subsequent requests to the server.
+
+## Unauthorised requests
+
+If a client makes a request to a resource that it does not have access to then the server **SHOULD** response with http code 401 and report a `"not_authorised"` error. For example, a response matching
+```javascript
+{
+    "status": "error",
+    "error": "not_authorised",
+    "error_description": string
+}
+```
+# Logging
+## Storing
+The server **MAY** provide a logging endpoint for all components to use.
+Any client with the `logging` privilege (see section on users) may `POST` to
+```
+http://backend.endpoint/log
+```
+with a request matching
+```javascript
+array({
+    "component": string,
+    "level": alternative(["info", "security", "warning", "error", "critical"]),
+    "value": anything
+})
+```
+If the server does not implement logging it **MUST** report an error "logging\_not\_enabled" and http error code 501.
+
+The server must store alongside each message the username of the logged in user who posted the message, and a timestamp that the message was received at. The server **MAY** selectively drop log messages (below a certain priority level, or from users who do not have a given privilege, for example) it is recommended that it exposes properties to control this (see section on properties). The server **MAY** also implement log rotation/expiration.
+
+If the request was valid and the server supports logging it **SHOULD** respond with an successful empty response.
+
+## Retrieving
+Clients authorised as a user with the `admin` privilege can access
+```
+http://backend.endpoint/log?before=<datetime>&after=<datetime>&level=<level>
+```
+Datetimes are formatted according to ISO 8601 in UTC.
+
+To retrieve log messages in the given date range and at log level `<level>` or above. Any parameter can be omitted in which case the given filter (before, after or log level) is not applied.
+
+If the server does not implement logging it **MUST** report an error "logging\_not\_enabled" and http error code 501.
+
+Otherwise, the server response should match
+```javascript
+array({
+    "component": string,
+    "level": alternative(["info", "security", "warning", "error", "critical"]),
+    "value": anything,
+    "username": string,
+    "timestamp": string
+})
+```
+`"timestamp"` should be an ISO 8601 formatted datetime in UTC. The array should be sorted newest to oldest.
+
+# Properties
+The server may wish to expose user/program configurable properties. These could control things such as backup policy, or provide an option to reset the server.
+
+## Listing
+Any authenticated client can access
+```
+http://backend.endpoint/properties
+```
+If the server does not expose a properties endpoint it **MUST** report an error "properties\_not\_implemented" and http error code 501.
+Otherwise, the server **SHOULD** respond with a list of properties, with the unwrapped response matching
+```javascript
+array({
+    "id": string,
+    "display": optional({
+        "category": string,
+        "group": string,
+        "display_name": string,
+        "description": string
+    }),
+    "read_only": boolean,
+    "type": alternative(["string", "integer", "boolean"]),
+    "value": alternative([string, integer, boolean])
+})
+```
+the list of properties **MAY** depend on the privileges of the logged in user.
+
+Properties providing a `"display"` key **SHOULD** be made available to the user as configuration options by the client. `"read_only"` properties should only be displayed and not given an edit option for.
+
+## Setting
+To update properties the client `POST`s to
+```
+http://backend.endpoint/properties?action=update
+```
+with body
+```javascript
+array({
+    "id": string,
+    "value": alternative([string, integer, boolean])
+})
+```
+The backend **SHOULD** only update properties given in body.
+
+If a property does not exist or is read only the server **SHOULD** respond with http response 400 and error "invalid\_property" and set `"error_data"` to the property's name.
+
+If an invalid property value is given the backend **SHOULD** respond with http response 400 and error "invalid\_property\_value" and set `"error_data"` to the property's name.
+
+# Users
+The backend server supports the concept of a users.
+Users have at least:
+- A username (an underscore prefix indicates a service account)
+- A password (this **SHOULD** be stored hashed and salted)
+- A set of privileges (the set of available privileges **MUST** include at least `admin` and `logging`)
+- A set of projects and project access rights (project access rights **MUST** include, at least, `project_admin` and `regular`)
+- Several metadata properties
+  - A metadata object that can be accessed by all, and updated by the user, "public\_user\_metadata"
+    - This could be used to store, for example, a display name and user biography
+  - A metadata object that can be accessed by all, and updated by users with the `admin` privilege, "public\_admin\_metadata"
+    - This could be used to store, for example, meta data about the users manager/supervisor, or that the account should be hidden from listings.
+  - A metadata object that can be accessed by the user, and updated by the user, "private\_user\_metadata"
+    - This could be used to store, for example, user interface preferences.
+  - A metadata object that can be accessed by users with the `admin` privilege, and updated by users with the `admin` privilege, "private\_admin\_metadata"
+    - This could be used to store, for example, a flag indicating that the account cannot be deleted.
+
+## Service accounts
+some users may be "service accounts" which are accounts intended to only be used by a server not acting on behalf of an end-user. From the server's perspective nothing distinguishes service accounts from normal accounts.
+
+From a clients perspective a service account is an account with a username that begins with an underscore.
+
+All groups have the reserved right to the service account formed by prefixing their group name (upper-case without a dash) with an underscore e.g. "\_ML1".
+
+If external servers require service accounts it is their responsibility to create and securely store the credentials. Typically during set-up these servers will require admin credentials in order to perform the creation but **SHOULD NOT** save these admin credentials.
+
+Clients presenting an interface **SHOULD** at least warn the end-user before altering/deleting these accounts.
+
+## Listing available privileges
+Any authorised client can access
+```
+http://backend.endpoint/user_privileges
+```
+
+And the server's response, unwrapped, must match
+```javascript
+array({
+    "privilege": string,
+    "description": string,
+    "internal": boolean
+})
+```
+
+`"internal"` indicates a privilege that should not be (by default) displayed or offered as a choice when assigning privileges.
+
+## Listing
+Clients can access
+```
+http://backend.endpoint/users
+```
+
+If the client is authorised as a user with the `admin` privilege  the server **MUST** respond with a list of users, with the unwrapped response matching
+```javascript
+array({
+    "username": string,
+    "privileges": array(string),
+    "projects": array({
+        "project_name": string,
+        "access_level": string
+    }),
+    "public_user_metadata": metadata,
+    "private_user_metadata": metadata,
+    "public_admin_metadata": metadata,
+    "private_admin_metadata": metadata
+})
+```
+
+If the client is authorised as a user without the `admin` privilege  the server **MUST** respond with a list of users, with the unwrapped response matching
+```javascript
+array({
+    "username": string,
+    "privileges": array(string),
+    "projects": array({
+        "project_name": string,
+        "access_level": string
+    }),
+    "public_user_metadata": metadata,
+    "private_user_metadata": not_present,
+    "public_admin_metadata": metadata,
+    "private_admin_metadata": not_present
+})
+```
+
+## Specific user
+Clients can access
+```
+http://backend.endpoint/users/<username>
+```
+
+If the client is authorised as a user with the `admin` privilege the server **MUST** respond with details of the particular user if they exist (unwrapped response):
+```javascript
+{
+    "username": string,
+    "privileges": array(string),
+    "projects": array({
+        "project_name": string,
+        "access_level": string
+    }),
+    "public_user_metadata": metadata,
+    "private_user_metadata": metadata,
+    "public_admin_metadata": metadata,
+    "private_admin_metadata": metadata
+}
+```
+
+If the client is authorised as a user without the `admin` privilege the server **MUST** respond with details of the particular user if they exist (unwrapped response):
+```javascript
+{
+    "username": string,
+    "privileges": array(string),
+    "projects": array({
+        "project_name": string,
+        "access_level": string
+    }),
+    "public_user_metadata": metadata,
+    "private_user_metadata": not_present,
+    "public_admin_metadata": metadata,
+    "private_admin_metadata": not_present
+}
+```
+
+or if the user does not exist it **MUST** return http response code 404 and a `"user_not_found"` error.
+
+## Current user
+Any client may access details about their currently logged in user from
+```
+http://backend.endpoint/current_user
+```
+and the server **MUST** respond with details of the particular user if they exist (unwrapped response):
+```javascript
+{
+    "username": string,
+    "privileges": array(string),
+    "projects": array({
+        "project_name": string,
+        "access_level": string
+    }),
+    "public_user_metadata": metadata,
+    "private_user_metadata": metadata,
+    "public_admin_metadata": metadata,
+    "private_admin_metadata": not_present
+}
+```
+
+## Creating
+A client with the `admin` privilege may create a user by issuing a `POST` request to
+```
+http://backend.endpoint/users/<username>?action=create
+```
+with body matching
+```javascript
+{
+    "privileges": array(string),
+    "password": string,
+    "public_user_metadata": optional(metadata),
+    "private_user_metadata": optional(metadata),
+    "public_admin_metadata": optional(metadata),
+    "private_admin_metadata": optional(metadata)
+}
+```
+(note that there is no need to indicate the username inside the request body)
+
+The metadata attributes **SHOULD** be assumed to be `initial_metadata` if not present in the request.
+
+The server **MUST** respond with one of:
+- a successful response without data
+- http code 400 with error "invalid\_privilege" (this **SHOULD** be done if an invalid privilege is specified)
+- http code 400 with error "invalid\_user" (this may be done if, for example, the password does not meet some complexity requirements, or an invalid privilege was specified)
+- http code 400 with error "user\_already\_exists" (this may be done if a user with the requested username already exists)
+- a metadata error.
+
+## Updating
+A client with the `admin` privilege may update a user by issuing a POST request to
+```
+http://backend.endpoint/users/<username>?action=update
+```
+with body matching
+```javascript
+{
+    "privileges": optional(array(string)),
+    "password": optional(string),
+    "public_user_metadata": optional(metadata),
+    "private_user_metadata": optional(metadata),
+    "public_admin_metadata": optional(metadata),
+    "private_admin_metadata": optional(metadata)
+}
+```
+(note that there is no need to indicate the username inside the request body)
+
+The server **SHOULD** only update the attributes listed in the request.
+Metadata **MUST** be processed in accordance with the "metadata" section of this specification.
+
+The server **MUST** respond with one of:
+- a successful response without data
+- http code 400 with error "invalid\_privilege" (this **SHOULD** be done if an invalid privilege is specified)
+- http code 400 with error "invalid\_user" (this may be done if, for example, the password does not meet some complexity requirements, or an invalid privilege was specified)
+- a metadata error.
+
+## Updating yourself
+A client may update a subset of the details of the user it is logged in as by issuing a POST request to
+```
+http://backend.endpoint/current_user?action=update
+```
+with body matching
+```javascript
+{
+    "password": optional({
+        "old": string,
+        "new": string
+    }),
+    "public_user_metadata": optional(metadata),
+    "private_user_metadata": optional(metadata),
+    "public_admin_metadata": not_present,
+    "private_admin_metadata": not_present
+}
+```
+The server should only attempt to update the attributes specified in the request.
+
+When updating the password the server **MUST** ensure that old password matches, if it does not the server **SHOULD** respond with response code 400 and error "invalid\_password".
+
+Metadata **MUST** be processed in accordance with the "metadata" section of this specification. Note that "public\_admin\_metadata" and "private\_admin\_metadata" **MUST** not be updated.
+
+The server **MAY** return an error "invalid\_user" and response code 400 if, for example, the password does not meet some complexity requirements.
+
+or return a metadata error.
+
+If the change was successful the server **MUST** respond with a sucessful empty response.
+
+## Deleting
+A client with the `admin` privilege may delete a user (who is not themself) by issuing a POST request to
+```
+http://backend.endpoint/users/<username>?action=delete
+```
+The server **MUST** respond with one of:
+- a successful response without data
+- http code 400 with error "invalid\_user" (this may be done if, for example, the password does not meet some complexity requirements, or an invalid privilege was specified)
+- http code 404 with error "user\_not\_found" (this **MUST** be done if the user cannot be found).
+
+## User properties
+The backend may wish to expose additional configuration options for individual users. the URL endpoint for this is:
+```
+http://backend.endpoint/users/<username>/properties
+```
+otherwise the behaviour is exactly the same as the global properties endpoint.
+These could be used to implement, for example, per user quotas or provide an option to expire all active login tokens.
+
+
+# Projects
+The backend server supports the concept of a project.
+Projects have at least:
+- A fixed name
+- A set of users and project access rights (project access rights **MUST** include, at least, `project_admin` and `regular`)
+- Public metadata object that is visible to all users but only editable by users with the `project_admin` access right, "public\_metadata"
+- Private metadata object that is visible to all users with at least the `regular` access right but only editable by users with the `project_admin` access right, "private\_metadata".
+- Private metadata object that is only visible and editable users with the `project_admin` access right, "admin\_metadata".
+
+Project names starting with an underscore are reserved.
+It is highly recommended that interfaces prevent end-users from creating projects with reserved names.
+The client **MAY** also choose to omit them from project listings presented to the end user (although direct access via URL could be useful).
+The client **SHOULD** at the very least issue a clear warning message before allowing an end-user to delete a reserved project.
+
+Groups are given exclusive access to projects that are prefixed by an underscore and then then their group name (uppercase without a dash). eg "\_ML1\_internal\_data".
+
+## Listing available roles
+Any authorised client can access
+```
+http://backend.endpoint/project_roles
+```
+
+The servers response, unwrapped, must match
+```javascript
+array({
+    "role": string,
+    "description": string,
+    "internal": boolean
+})
+```
+
+`"internal"` indicates a role that should not be (by default) displayed or offered as a choice when assigning roles.
+
+A role **MUST NOT** be named "none".
+
+## Listing
+All clients can access
+```
+http://backend.endpoint/projects
+```
+
+The server **MUST** respond with a list of projects, with the unwrapped response matching
+```javascript
+array({
+    "project_name": string,
+    "users": array({
+        "username": string,
+        "access_level": string
+    }),
+    "public_metadata": metadata,
+    "private_metadata": optional(metadata),
+    "admin_metadata": optional(metadata)
+})
+```
+`"private_metadata"` **SHOULD** only be present when the client has at least `regular` access to the given projects.
+
+`"admin_metadata"` **SHOULD** only be present when the client has at least `project_admin` access to the given projects.
+
+## Specific project
+Clients that have at least `regular` access to a given project can request
+```
+http://backend.endpoint/projects/<project_name>
+```
+
+The server **MUST** respond with details of the particular project if it exists (unwrapped response):
+```javascript
+{
+    "project_name": string,
+    "users": array({
+        "username": string,
+        "access_level": string
+    }),
+    "public_metadata": metadata,
+    "private_metadata": metadata,
+    "admin_metadata": optional(metadata)
+}
+```
+`"admin_metadata"` **SHOULD** only be present when the client has at least `project_admin` access to the given projects.
+Or, if the project does not exist, it **MUST** return http response code 404 and a "project\_not\_found" error.
+
+## Creating
+A client with the `admin` privilege may create a project by issuing a POST request to
+```
+http://backend.endpoint/projects/<project_name>?action=create
+```
+with body matching
+```javascript
+{
+    "public_metadata": optional(metadata),
+    "private_metadata": optional(metadata),
+    "admin_metadata": optional(metadata)
+}
+```
+(note that there is no need to indicate the project name inside the request body)
+the metadata attributes **SHOULD** be assumed to be `inital_metdata` if not present in the request.
+
+Metadata **MUST** be processed in accordance with the "metadata" section of this specification.
+
+If the project is created then the current user **SHOULD** be given `project_admin` access to the project.
+
+The server **MUST** respond with one of:
+- a successful response without data
+- http code 400 with error "invalid\_project"
+- http code 400 with error "project\_already\_exists" (this **MUST** be done if the project exists already).
+- a metadata error.
+
+## Updating
+A client with the `project_admin` access right may update a project by issuing a POST request to
+```
+http://backend.endpoint/projects/<project_name>?action=update
+```
+with body matching
+```javascript
+{
+    "public_metadata": optional(metadata),
+    "private_metadata": optional(metadata),
+    "admin_metadata": optional(metadata)
+}
+```
+(note that there is no need to indicate the project name inside the request body)
+If the user does not have the `admin` privilege and the `"admin_metadata"` was specified in the request the server should return an invalid request error.
+
+The server **SHOULD** only update the attributes listed in the request.
+Metadata **MUST** be processed in accordance with the "metadata" section of this specification.
+
+The server **MUST** respond with one of:
+- a successful response without data
+- http code 400 with error "invalid\_project"
+- http code 400 with error "project\_not\_found" (this **MUST** be done if the project cannot be found)
+- a metadata error.
+
+## Deleting
+A client with the `admin` privilege (**NOTE** different to `project_admin` access rights) may delete a project by issuing a POST request to
+```
+http://backend.endpoint/projects/<project_name>?action=delete
+```
+
+The server **MUST** respond with one of:
+- a successful response without data
+- http code 400 with error "project\_not\_found".
+
+## Project grants
+A client with the `project_admin` access right or with the `admin` privilege may change a users access rights to a project by issuing a POST request to
+```
+http://backend.endpoint/projects/<project_name>?action=update_grant
+```
+
+with request matching
+```javascript
+{
+    "username": string,
+    "access_level": string
+}
+```
+where access level is a valid access level or the value `"none"` to remove access. If "access\_level" does not meet these criteria then the server **SHOULD** return an error "invalid\_access\_level" with status code 400.
+
+The server **MUST** respond "project\_not\_found" and response code 404 if the project cannot be found.
+
+The server **MUST** respond "user\_not\_found" and response code 404 if the user cannot be found.
+
+The server **MUST** respond with a successful empty response if the access level was updated.
+
+## Project properties
+The backend may wish to expose additional configuration options for individual projects. The URL endpoint for this is:
+```
+http://backend.endpoint/projects/<project_name>/properties
+```
+otherwise the behaviour is exactly the same as the global properties endpoint.
+These could be used to implement, for example, per project storage quotas or provide an option to log all file accesses.
+
+# File access
+**NOTE:** all file operations require that clients have at least `regular` access to the project.
+
+## File paths and IDs
+Each project is associated with a file store. Files are organised into directories. Valid file/directory names are Unicode strings that do not contain `"/"` or `"\"`. Valid file names must be at least a single character long.
+
+`"."` and `".."` are **not** valid file/directory names.
+
+The server **MAY** consider names containing control characters from C0 and C1 as defined by in ISO 6429 to be invalid. When these characters are specified as part of a URL the server behaviour is undefined.
+
+Valid paths consist of valid file names separated by a single `"/"`.
+The server **MAY** impose a limit on the length of path names but this **SHOULD** be no smaller than 1024 Unicode characters, paths longer than this **MAY** be considered invalid by the server.
+
+If an invalid path is presented the server **SHOULD** return response code 400 and error "invalid\_path".
+
+The path "" (empty string) refers to the root directory of the project.
+
+The path "\_reserved" is reserved for a directory. All sub-paths are all reserved.
+Groups are given exclusive access to the subdirectory given by their group name (upper-case without a dash) e.g. "\_reserved/ML1".
+Clients **MAY** hide the reserved directory from end-users and **MAY** hide the directory from listings (although allowing access with the direct path may be helpful).
+
+A file path `<path>` inside project `<project_name>` is accessed under the URL
+```
+http://backend.endpoint/projects/<project_name>/files/<path>
+```
+
+Files also have an ID associated with them, if the ID of a file is known to be `<id>` then the file can also be accessed under the path
+```
+http://backend.endpoint/projects/<project_name>/files_by_id/<id>
+```
+
+If a request (that is not a create request) is made for a path/ID that does not exist then the server **SHOULD** respond with response code 404 and error message "file\_not\_found".
+
+The server **MUST NOT** reuse file IDs - in particular if a file is deleted and then recreated its ID **MUST** change. Clients are recommended to first access a file by path, but subsequent accesses during the same session should be made by ID. This prevents a deleted and then recreated file from causing races.
+
+## Views
+Files are accessed under a given view specified by setting the query parameter `view=<view_name>`. All files support at least the `"meta"` view. If a view is not specified then the `"meta"` view is assumed.
+
+All files that are not directories support access to the raw bytes with the `"raw"` view.
+
+## Meta view
+If a meta request is made for the meta view of a given file, e.g.:
+```
+http://backend.endpoint/projects/<project_name>/files/<path>?view=meta
+```
+the server **MUST** respond with an unwrapped response matching
+```javascript
+{
+    "file_path": string,
+    "file_name": string,
+    "id": string,
+    "supported_views": {},
+    "type": string,
+    "metadata": metadata,
+    "status": alternative([
+        "uploading",
+        "preprocessing",
+        "ready"
+    ])
+}
+```
+`"file_path"` gives the full path to the file, `"file_name"` gives this path without any parent directories (e.g. the basename of the path).
+
+`"supported_views"` is an object with keys corresponding to the supported views and values corresponding to additional data provided by that view.
+
+`"type"` is a file type. The type "generic" is for files of unknown filetype, and therefore support only `"meta"` and `"raw"` views. The type "directory" is for directories.
+
+`"metadata"` provides metadata for the file; this is client controlled. When a file is first created the value of its metadata **MUST** be `initial_metadata`.
+
+This metadata could be used, for example, to attach annotations to images.
+
+`"status"` gives the current status of the file:
+- When a file is first created/written to its status becomes "uploading" (it still supports the `"raw"` view).
+- After the client has indicated that the upload is final (see the upload section) the state changes to "preprocessing" during which the server **SHOULD** attempt to determine a more specific file type and supported views.
+- Once the server has finalised this process the status changes to "ready".
+- The server **SHOULD** deny writes when file is not in the "uploading" state.
+- Clients **MAY** keep a file in the uploading state indefinitely, although this should not be done for end-user facing files, and generally only files in the "\_reserved" directory.
+
+Clients providing an end-user interface to the files **SHOULD** indicate if a file is not in the "ready" state, for example by placing an icon or badge next to the file.
+
+## Meta view - directories
+If the file is a directory and the query parameter "include\_children" is included in the request then the meta view will additionally match:
+```javascript
+{
+    "children": array({
+        "file_path": string,
+        "file_name": string,
+        "id": string,
+        "type": string,
+        "status": alternative([
+            "uploading",
+            "preprocessing",
+            "ready"
+        ])
+    })
+}
+```
+where the "children" array contains the meta view for all the children of the directory. *NOTE:* the "include\_children" option is not recursive, child directories will not list their children.
+
+## Meta view - raw files
+If files support the raw view then the meta view should match
+```javascript
+{
+    "supported_views": {
+        "raw": {
+            "size": integer
+        }
+    }
+}
+```
+where size give the size of the file in bytes.
+
+## Unsupported views
+If the client makes a request using an unknown or unsupported view then the server **MUST** respond with code 400 and error 'unsupported\_file\_view'.
+
+## Raw file view
+The "raw" file view (accessed by setting "view=raw" in the query string) provides access to the file as a stream of bytes.
+The following parameters are accepted:
+
+| name   | description                                                                                                      | if not specified                     |
+|--------|------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| offset | offset into the file, in bytes - the server will omit this number of bytes from the start of the response        | assume 0                             |
+| length | total number of bytes to retrieve - server will truncate the response so that it is at most "length" bytes long. | data is not truncated before sending |
+
+The server **MUST** respond with mimetype `application/octet-stream'`.
+
+## Uploading
+files are uploaded by sending a POST request to the file URL either without the query parameter "action" or with it set to the value "upload".
+The following additional parameters **MUST** be accepted by the server
+
+| name      | description                                                                                                                                                                   | if not specified                                                                      |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| overwrite | allow file overwrites - do not cause an error if the file already exists. When accessing a file by id this parameter **MUST** be specified otherwise the request is not valid. | exit with error code 400 and message "file\_already\_exists" if the file already exists |
+| offset    | seek to the specified offset in the file before writing - if the file has to be extended to meet this request then the new space will be filled with zeros                    | data is written to the start of the file                                              |
+| truncate  | after writing the size of the file is reduced so that the last byte in the file is the last byte written                                                                      | file size never shrinks                                                               |
+| final     | If this is the last write to file, **SHOULD** trigger the server to change the file status and do some prepossessing                                                          | assumed not the final upload                                                          |
+
+**NOTE:** A file can be truncated to a give size by issuing an empty POST request with parameters `overwrite=true&offset=<new_size>&truncate=true`
+
+**NOTE:** File uploads without the overwrite flag **SHOULD** create the file atomically (e.g. mimic the behaviour of `open(..., O_RDWR | O_CREAT | O_EXCL)`). This could be used as a coarse form of locking.
+
+**NOTE:** File operations on overlapping regions (or when both operations require extending the file) are not required to be atomic.
+
+If the parent directory does not exist (or is not a directory) the server **SHOULD** respond with code 404 and error message "invalid\_parent\_directory".
+
+If the specified file is a directory and the request includes the overwrite parameter then the server **SHOULD** respond with code 400 and error message "not\_a\_file". If the request does not specify overwrite then the response should be "file\_already\_exists" as specified in default behaviour for the overwrite parameter.
+
+If the file is not in the "uploading" state the server **SHOULD** respond with code 400 and error message "invalid\_file\_state".
+
+If the write was successful the server **MUST** respond with a response which when unwrapped matches.
+```javascript
+{
+    "id": string,
+    "created": boolean
+}
+```
+where "id" gives the id of the file, and "created" indicates that the file did not previously exist.
+
+**NOTE: Uploading files**
+Clients that wish to upload files are recommended to follow these steps:
+- Where possible, split the file into fixed size chunks (e.g. 4MiB)
+- Upload the first chunk
+- Upload the middle chunks with the "overwrite" option
+- Upload the final chunk with the "overwrite" and "final" options
+- (If the file is to be uploaded in a single chunk only the "final" option should be used for this chunk.)
+
+This prevents a race condition whereby multiple clients try to upload a file with the same name - in this case only one will succeed.
+Chunking allows resuming interrupted uploads as well as progress reporting to the end user.
+
+## Changing metadata
+A POST request sent to a file path with query parameter `"action=set_metadata"` triggers the server to change the files client-specified metadata.
+The client request should match the `metadata` template.
+
+Metadata **MUST** be processed in accordance with the "metadata" section of this specification.
+The server **MUST** respond with an empty successful response or a metadata error (or a "file\_not\_found" error).
+
+## Creating directories
+If a POST request is made to a non existent path with query parameter `"action=mkdir"` an attempt to make a new directory is made.
+
+If there is already a file with this name the server responds with status code 400 and error message "file\_already\_exists".
+
+If the parent directory does not exist (or is not a directory) then the server **SHOULD** respond with error code 404 and error message "invalid\_parent\_directory".
+
+Directories are always in the "ready" state.
+
+If directory creation is successful the server's unwrapped response **MUST** match
+```javascript
+{
+    "id": string
+}
+```
+where id gives the id of the newly created directory.
+
+## Deleting
+If a POST request is made to a non existent path with query parameter `"action=delete"` an attempt to delete the file/directory is made.
+
+Deletes on directories delete their contents and are recursive.
+
+If an attempt to delete the root directory is made the server **MUST** respond with error code 400 and error message "invalid\_operation".
+
+The server **MUST** return an empty successful response if the deletion succeeded.
+
+## Moving
+A file can be moved by making a post request to the file path with `"action=move"` and request body matching
+
+```javascript
+alternative([
+    {
+        "id": string,
+        "path": not_present
+    },
+    {
+        "id": not_present,
+        "path": string
+    }
+])
+```
+If a path is given the file may or may not currently exist, but the parent directory **MUST** exist - if it does not (or is not a directory) then the server **SHOULD** respond with error code 404 and error message "invalid\_parent\_directory".
+
+If an id is given it **MUST** exist - the server **SHOULD** respond with a typical 404 and "file\_not\_found" response if it does not.
+
+If an attempt is made to move a directory inside itself or to replace a directory with one of its children the server **SHOULD** respond with http status 400 and error "invalid\_parent"
+
+The effect is as follows (atomically):
+
+- The to file is deleted if it currently exists
+- The from file is relocated to the to files old path. It maintains its ID, metadata, status file contents etc.
+- The from file is no longer available under its old path
+
+If successful the server **SHOULD** return a successful empty response.
+
+## Copying
+A file (that is not a directory) can be copied by making a post request to the file path with `"action=copy"` and request body matching
+
+```javascript
+alternative([
+    {
+        "id": string,
+        "path": not_present
+    },
+    {
+        "id": not_present,
+        "path": string
+    }
+])
+```
+If a directory is specified the server **SHOULD** respond with http status 400 and error type "not\_a\_file".
+
+If a path is given the file may or may not currently exist, but the parent directory **MUST** exist - if it does not (or is not a directory) then the server **SHOULD** respond with error code 404 and error message "invalid\_parent\_directory".
+
+If an id is given it **MUST** exist - the server **SHOULD** respond with a typical 404 and "file\_not\_found" response if it does not.
+
+If an attempt is made to replace a directory with one of its children the server **SHOULD** respond with http status 400 and error "invalid\_parent"
+
+The effect is as follows (atomically):
+
+- The to file is deleted if it currently exists
+- The from file is copied to the to files old path. It maintains its metadata, status file contents etc. **BUT NOT ITS ID**
+
+If successful the server **SHOULD** return a successful empty response.
+
+## Extra file types
+The file type (and hence supported views) of a file are determined by some unspecified process on the backend, this may include looking at the file extension and possibly the file contents. The server **SHOULD** recognise valid files that have the correct extension and file contents. If the client requires that a file type is correctly recognised it **SHOULD** ensure that it is uploaded under a file name with the correct extension.
+
+This determination only happens once the file is made "final" by providing the "final" query parameter as part of the upload. While this is happening the file state should be "prepossessing", once complete the server will set the file status to "ready".
+
+# Tabular files
+A file type that contains tabular data (e.g. excel, CSV) should report its file type as tabular in its meta view:
+```javascript
+{
+    "type": "tabular"
+}
+```
+Additionally it should support the tabular view:
+```javascript
+{
+    "supported_views": {
+        "tabular": {
+            "columns": array(string),
+            "rows": integer
+        }
+    }
+}
+```
+Where columns gives all of the names of the columns, and rows the number of (non-header) rows.
+
+## The tabular view
+The tabular view supports the following parameters
+
+| name     | description                                                                                                                                        | if not specified           |
+|----------|----------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
+| rowstart | first non-header row to be included in the output                                                                                                  | assume = 0                 |
+| rowcount | maximum number of non header rows to include in the output                                                                                         | all matching rows included |
+| cols     | comma separated list of all column indices (zero based indices into the "columns" field of the meta view) for columns to be included in the output | all columns included       |
+
+The mimetype of a successful response *MUST* be "text/csv". The CSV response **always** includes the header row.
+
+If rowstart is passed the end of the file then no non-header rows are returned.
+
+If cols contains invalid entries then the server **SHOULD** respond with code 400 and error "invalid\_request".
+
+
+# Zoomable image files
+A file type that contains images that can be rescaled and zoomed. The file type, as seen in the meta view, should be:
+```javascript
+{
+    "type": "scalable_image"
+}
+```
+Additionally it should support the following view:
+```javascript
+{
+    "supported_views": {
+        "scalable_image": {
+            "width": integer,
+            "height": integer,
+            "channels": array({
+                "channel_id": string,
+                "channel_name": string,
+                "metadata": optional({})
+            }),
+            "real_width": optional({
+                "value": integer,
+                "units": alternative(["mm", "um", "nm"])
+            }),
+            "real_height": optional({
+                "value": integer,
+                "units": alternative(["mm", "um", "nm"])
+            }),
+            "metadata": optional({})
+        }
+    }
+}
+```
+where width and height give the image dimensions (at the maximum scale level) and the metadata attributes **MAY** contain metadata extracted from the image.
+
+## The Scalable Image view
+This view supports the following parameters
+
+| name         | description                                                                                                                  | if not specified                                |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| channel\_name | image channel to operate on                                                                                                  | send response 400, with error "invalid\_request" |
+| zoom\_level   | rescales the image before returning to client to be `requested\_width / zoom\_level` by `requested\_height / zoom\_level` pixels | assume = 1                                      |
+| x\_offset     | x offset, in unscaled pixels, of the region requested from the top left corner                                               | assume = 0                                      |
+| y\_offset     | y offset, in unscaled pixels, of the region requested from the top left corner                                               | assume = 0                                      |
+| width        | width, in unscaled pixels, of the region requested                                                                           | set so that x\_offset + width = image\_width      |
+| height       | height, in unscaled pixels, of the region requested                                                                          | set so that y\_offset + height = image\_height    |
+
+
+The mimetype of a successful response **MUST** be "image/png".
+
+If the region specified extends outside the image the server should fill in the remainder of the image with the colour `#000000ff`.
+
+x\_offset, y\_offset, width and height **SHOULD** all be a multiple of zoom\_level otherwise the server **MAY** respond with response code 400 and error "invalid\_request".


### PR DESCRIPTION
Currently, when HCI wants to display all of the folders in a directory, it sends a GET request to the path of the directory with the query parameter `"include_children"`, upon which it receives a response matching

```
{
    "children": array({
        "file_path": string,
        "file_name": string,
        "id": string,
        "supported_views": {},
        "type": string,
        "metadata": metadata,
        "status": alternative([
            "uploading",
            "preprocessing",
            "ready"
        ])
    })
}
```

However, all of the information contained in `"supported_views"` is not used until the file itself is selected. 

Creating this could potentially be expensive for the backend, since it involves parsing every CSV and extracting metadata from every image in the selected directory. The same is also true for the `"metadata"` field as well. (I know some groups have all of this stored in a database, but still.) 

Thus, the protocol here should be changed to

```
{
    "children": array({
        "file_path": string,
        "file_name": string,
        "id": string,
        "type": string,
        "status": alternative([
            "uploading",
            "preprocessing",
            "ready"
        ])
    })
}
```

This reduces unnecessary work for the backend server. 